### PR TITLE
Feature/map: Updates to Tiles and room change handling

### DIFF
--- a/src/main/java/it/unibo/ruscodc/model/GameModel.java
+++ b/src/main/java/it/unibo/ruscodc/model/GameModel.java
@@ -3,6 +3,7 @@ package it.unibo.ruscodc.model;
 import it.unibo.ruscodc.model.actors.Actor;
 import it.unibo.ruscodc.model.gamemap.Room;
 import it.unibo.ruscodc.utils.Direction;
+import it.unibo.ruscodc.utils.Pair;
 
 import java.util.List;
 
@@ -38,9 +39,9 @@ public interface GameModel {
 
     /**
      * Change the current room.
-     * @param dir the direction in which the player is moving.
+     * @param pos the coordinates of the passage
      */
-    void changeRoom(Direction dir);
+    void changeRoom(Pair<Integer, Integer> pos);
 
     /**
      * Change the entire floor allowing the player into the next level.

--- a/src/main/java/it/unibo/ruscodc/model/GameModelImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/GameModelImpl.java
@@ -5,8 +5,14 @@ import it.unibo.ruscodc.model.actors.hero.Hero;
 import it.unibo.ruscodc.model.gamemap.Floor;
 import it.unibo.ruscodc.model.gamemap.FloorImpl;
 import it.unibo.ruscodc.model.gamemap.Room;
+import it.unibo.ruscodc.model.gamemap.Tile;
+import it.unibo.ruscodc.model.interactable.Door;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Direction;
+import it.unibo.ruscodc.utils.Pair;
+
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This class process the input received that will help the view to print all.
@@ -70,8 +76,20 @@ public class GameModelImpl implements GameModel {
     }
 
     @Override
-    public void changeRoom(final Direction dir) {
-        this.floor.goToRoom(dir);
+    public void changeRoom(final Pair<Integer, Integer> pos) {
+        final Room current = this.floor.getCurrentRoom();
+        if (!current.isInRoom(pos)) {
+            return;
+        }
+        if (pos.getX() == 0) {
+            this.floor.goToRoom(Direction.LEFT);
+        } else if (pos.getY() == 0) {
+            this.floor.goToRoom(Direction.UP);
+        } else if (pos.getY().equals(current.getSize().getY())) {
+            this.floor.goToRoom(Direction.DOWN);
+        } else if (pos.getX().equals(current.getSize().getX())) {
+            this.floor.goToRoom(Direction.RIGHT);
+        }
     }
 
     @Override

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/AbstractTile.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/AbstractTile.java
@@ -1,6 +1,8 @@
 package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
+import it.unibo.ruscodc.model.actors.Actor;
+import it.unibo.ruscodc.model.effect.SingleTargetEffect;
 import it.unibo.ruscodc.utils.Pair;
 
 import java.util.Optional;
@@ -34,6 +36,11 @@ public abstract class AbstractTile implements Tile, Entity {
     }
 
     @Override
+    public boolean isTrap() {
+        return false;
+    }
+
+    @Override
     public boolean put(final Entity obj) {
         if (this.content != null) {
             return false;
@@ -52,6 +59,11 @@ public abstract class AbstractTile implements Tile, Entity {
         final Optional<Entity> content = this.get();
         this.content = null;
         return content;
+    }
+
+    @Override
+    public SingleTargetEffect getEffect() {
+        return (Actor a) -> { };
     }
 
     @Override

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/AbstractTile.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/AbstractTile.java
@@ -3,6 +3,7 @@ package it.unibo.ruscodc.model.gamemap;
 import it.unibo.ruscodc.model.Entity;
 import it.unibo.ruscodc.model.actors.Actor;
 import it.unibo.ruscodc.model.effect.SingleTargetEffect;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Pair;
 
 import java.util.Optional;
@@ -13,7 +14,7 @@ import java.util.Optional;
 public abstract class AbstractTile implements Tile, Entity {
     private final Pair<Integer, Integer> position;
     private final boolean isAccessible;
-    private Entity content;
+    private Interactable content;
 
     /**
      * Creates a <code>Tile</code> at the specified position and sets its accessibility.
@@ -41,7 +42,7 @@ public abstract class AbstractTile implements Tile, Entity {
     }
 
     @Override
-    public boolean put(final Entity obj) {
+    public boolean put(final Interactable obj) {
         if (this.content != null) {
             return false;
         }
@@ -50,13 +51,13 @@ public abstract class AbstractTile implements Tile, Entity {
     }
 
     @Override
-    public Optional<Entity> get() {
+    public Optional<Interactable> get() {
         return Optional.ofNullable(this.content);
     }
 
     @Override
-    public Optional<Entity> empty() {
-        final Optional<Entity> content = this.get();
+    public Optional<Interactable> empty() {
+        final Optional<Interactable> content = this.get();
         this.content = null;
         return content;
     }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/FloorImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/FloorImpl.java
@@ -59,7 +59,8 @@ public class FloorImpl implements Floor {
         final int left = MAX_ROOMS_NUMBER - this.getNRoomExplored();
         final int prob = new Random().nextInt(0, left + 1);
         if (prob == 0) {
-            return this.roomFactory.stairsRoom();
+            // TODO:
+            //return this.roomFactory.stairsRoom();
         }
         return this.roomFactory.randomRoom();
     }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/FloorTrapTileImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/FloorTrapTileImpl.java
@@ -1,0 +1,74 @@
+package it.unibo.ruscodc.model.gamemap;
+
+import it.unibo.ruscodc.model.actors.Actor;
+import it.unibo.ruscodc.model.actors.stat.StatImpl;
+import it.unibo.ruscodc.model.effect.SingleTargetEffect;
+import it.unibo.ruscodc.model.gamecommand.GameCommand;
+import it.unibo.ruscodc.model.gamecommand.quickcommand.DoNothing;
+import it.unibo.ruscodc.model.interactable.Interactable;
+import it.unibo.ruscodc.utils.Pair;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * The <code>FloorTrapTileImpl</code> class represents a special <code>Tile</code>
+ * containing a trap placed on the floor.
+ */
+public class FloorTrapTileImpl extends FloorTileImpl implements Interactable {
+    private int damage = 5;
+    private boolean isReady = true;
+    private Consumer<FloorTrapTileImpl> postTriggered = (self) -> { };
+
+    /**
+     * Constructs a floor trap with 5 as default damage produced.
+     * @param pos the position at which place the <code>Tile</code>
+     */
+    public FloorTrapTileImpl(final Pair<Integer, Integer> pos) {
+        super(pos, true);
+    }
+
+    /**
+     *
+     * @param pos the position at which place the <code>Tile</code>
+     * @param damage the damage inflicted by the trap
+     */
+    public FloorTrapTileImpl(final Pair<Integer, Integer> pos, final int damage) {
+        super(pos, true);
+        this.damage = damage;
+    }
+
+    @Override
+    public boolean isTrap() {
+        return true;
+    }
+
+    /**
+     * Set what happens after the trap has been triggered.
+     * @param post
+     */
+    public void setPostTriggered(Consumer<FloorTrapTileImpl> post) {
+        this.postTriggered = post;
+    }
+
+    @Override
+    public SingleTargetEffect getEffect() {
+        return (Actor target) -> {
+            if (this.isReady) {
+                target.modifyStat(StatImpl.StatName.HP, -this.damage);
+                this.postTriggered.accept(this);
+            }
+        };
+    }
+
+    @Override
+    public String getName() {
+        return "It's a trap!";
+    }
+
+    @Override
+    public GameCommand interact() {
+        this.isReady = false;
+        return new DoNothing();
+    }
+}

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/FloorTrapTileImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/FloorTrapTileImpl.java
@@ -8,16 +8,19 @@ import it.unibo.ruscodc.model.gamecommand.quickcommand.DoNothing;
 import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Pair;
 
+import java.util.Random;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * The <code>FloorTrapTileImpl</code> class represents a special <code>Tile</code>
  * containing a trap placed on the floor.
+ * By default, the trap can be triggered multiple times, producing 5 points
+ * of damage each time and can be disabled with a simple interaction.
  */
 public class FloorTrapTileImpl extends FloorTileImpl implements Interactable {
     private int damage = 5;
     private boolean isReady = true;
+    private int disableSuccessRate = 100;
     private Consumer<FloorTrapTileImpl> postTriggered = (self) -> { };
 
     /**
@@ -29,15 +32,23 @@ public class FloorTrapTileImpl extends FloorTileImpl implements Interactable {
     }
 
     /**
-     *
-     * @param pos the position at which place the <code>Tile</code>
-     * @param damage the damage inflicted by the trap
+     * Sets the trap's damage. The damage is set to 5 by default.
+     * @param dmg the damage that the trap will inflict to the player.
      */
-    public FloorTrapTileImpl(final Pair<Integer, Integer> pos, final int damage) {
-        super(pos, true);
-        this.damage = damage;
+    public void setDamage(final int dmg) {
+        this.damage = dmg;
     }
 
+    /**
+     * Sets the success rate for the interaction with the trap.
+     * The interaction can be used to disable the trap.
+     * @param successRate the new success rate
+     */
+    public void setDisableSuccessRate(final int successRate) {
+        this.disableSuccessRate = successRate;
+    }
+
+    /** {@inheritDoc} */
     @Override
     public boolean isTrap() {
         return true;
@@ -45,12 +56,13 @@ public class FloorTrapTileImpl extends FloorTileImpl implements Interactable {
 
     /**
      * Set what happens after the trap has been triggered.
-     * @param post
+     * @param post a <code>Consumer</code> taking the current <code>FloorTrapTileImpl</code> as object consumed
      */
-    public void setPostTriggered(Consumer<FloorTrapTileImpl> post) {
+    public void setPostTriggered(final Consumer<FloorTrapTileImpl> post) {
         this.postTriggered = post;
     }
 
+    /** {@inheritDoc} */
     @Override
     public SingleTargetEffect getEffect() {
         return (Actor target) -> {
@@ -61,14 +73,21 @@ public class FloorTrapTileImpl extends FloorTileImpl implements Interactable {
         };
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return "It's a trap!";
     }
 
+    /**
+     * Disables the trap.
+     * @return a <code>DoNothing</code> command.
+     */
     @Override
     public GameCommand interact() {
-        this.isReady = false;
+        if (new Random().nextInt(100) < this.disableSuccessRate) {
+            this.isReady = false;
+        }
         return new DoNothing();
     }
 }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
@@ -94,6 +94,16 @@ public class RectangleRoomImpl implements Room {
         return tile.get().put(obj);
     }
 
+    @Override
+    public Optional<Tile> get(Pair<Integer, Integer> pos) {
+        if (this.isInRoom(pos)) {
+            return this.tiles.stream()
+                    .filter(tile -> tile.getPosition().equals(pos))
+                    .findFirst();
+        }
+        return Optional.empty();
+    }
+
     /** {@inheritDoc} */
     @Override
     public boolean isAccessible(final Pair<Integer, Integer> pos) {

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
@@ -2,6 +2,7 @@ package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
 import it.unibo.ruscodc.model.actors.Actor;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Direction;
 import it.unibo.ruscodc.utils.Pair;
 
@@ -67,7 +68,7 @@ public class RectangleRoomImpl implements Room {
 
     /** {@inheritDoc} */
     @Override
-    public Set<Entity> getObjectsInRoom() {
+    public Set<Interactable> getObjectsInRoom() {
         return this.tiles.stream()
                 .filter(tile -> tile.get().isPresent())
                 .map(tile -> tile.get().orElseThrow())
@@ -84,7 +85,7 @@ public class RectangleRoomImpl implements Room {
 
     /** {@inheritDoc} */
     @Override
-    public boolean put(final Pair<Integer, Integer> pos, final Entity obj) {
+    public boolean put(final Pair<Integer, Integer> pos, final Interactable obj) {
         final Optional<Tile> tile = this.tiles.stream()
                 .filter(t -> t.getPosition().equals(pos))
                 .findFirst();

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/RectangleRoomImpl.java
@@ -40,7 +40,7 @@ public class RectangleRoomImpl implements Room {
                 if (i == 0 || j == 0 || i == this.size.getX() || j == this.size.getY()) {
                     this.tiles.add(tf.createBaseWallTile(i, j, this.size));
                 } else {
-                    this.tiles.add(tf.createBaseFloorTile(i, j));
+                    this.tiles.add(tf.createRandomFloorTile(i, j));
                 }
             }
         }
@@ -132,9 +132,7 @@ public class RectangleRoomImpl implements Room {
         if (this.connectedRooms.get(dir).isPresent()) {
             return false;
         }
-
         this.connectedRooms.put(dir, Optional.of(other));
-
         other.addConnectedRoom(dir.getOpposite(), this);
         return true;
     }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/Room.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/Room.java
@@ -51,6 +51,13 @@ public interface Room {
     boolean put(Pair<Integer, Integer> pos, Entity obj);
 
     /**
+     * Returns the <code>Tile</code> at the specified position.
+     * @param pos the position of the <code>Tile</code> to retrieve
+     * @return an <code>Optional</code> containing the tile at said position or an empty <code>Optional</code> if the position is out of the room
+     */
+    Optional<Tile> get(Pair<Integer, Integer> pos);
+
+    /**
      * Returns whether the specified position is accessible to an actor.
      * @param pos the position in which move the actor
      * @return <code>True</code> if the tile at the specified position is

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/Room.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/Room.java
@@ -3,6 +3,7 @@ package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
 import it.unibo.ruscodc.model.actors.Actor;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Direction;
 import it.unibo.ruscodc.utils.Pair;
 
@@ -33,7 +34,7 @@ public interface Room {
      * Returns the objects in the room.
      * @return a set representing the objects in the room
      */
-    Set<Entity> getObjectsInRoom();
+    Set<Interactable> getObjectsInRoom();
 
     /**
      * Returns the <code>Room</code>'s tiles as <code>Entity</code>.
@@ -48,7 +49,7 @@ public interface Room {
      * @return <code>True</code> if the entity has been placed correctly,
      * <code>False</code> otherwise.
      */
-    boolean put(Pair<Integer, Integer> pos, Entity obj);
+    boolean put(Pair<Integer, Integer> pos, Interactable obj);
 
     /**
      * Returns the <code>Tile</code> at the specified position.

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/RoomFactory.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/RoomFactory.java
@@ -32,5 +32,5 @@ public interface RoomFactory {
      * the next level.
      * @return a randomly generated room to the next level
      */
-    Room stairsRoom();
+    //Room stairsRoom(); // TODO:
 }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/RoomFactoryImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/RoomFactoryImpl.java
@@ -13,13 +13,9 @@ public class RoomFactoryImpl implements RoomFactory {
     /** {@inheritDoc} */
     @Override
     public Room randomRoom() {
-        if (this.rnd.nextInt() % 2 == 0) {
-            return this.squareRoom(this.rnd.nextInt(MAX_ROOM_SIZE));
-        }
-        return this.rectangleRoom(
-                this.rnd.nextInt(MAX_ROOM_SIZE),
-                this.rnd.nextInt(MAX_ROOM_SIZE)
-        );
+        return (this.rnd.nextInt() % 2 == 0) ?
+                this.squareRoom(this.rnd.nextInt(MAX_ROOM_SIZE)) :
+                this.rectangleRoom(this.rnd.nextInt(MAX_ROOM_SIZE), this.rnd.nextInt(MAX_ROOM_SIZE));
     }
 
     /** {@inheritDoc} */
@@ -34,13 +30,13 @@ public class RoomFactoryImpl implements RoomFactory {
         return new RectangleRoomImpl(width, height);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public Room stairsRoom() {
-        final Room base = this.randomRoom();
-        // TODO:
-        //base.addStairs(Direction.UNDEFINED);
-        return base;
-    }
+// TODO:
+//    /** {@inheritDoc} */
+//    @Override
+//    public Room stairsRoom() {
+//        final Room base = this.randomRoom();
+//        //base.addStairs(Direction.UNDEFINED);
+//        return base;
+//    }
 
 }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/Tile.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/Tile.java
@@ -2,6 +2,7 @@ package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
 import it.unibo.ruscodc.model.effect.SingleTargetEffect;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Pair;
 
 import java.util.Optional;
@@ -41,7 +42,7 @@ public interface Tile {
      * @return <code>True</code> if the <code>Entity</code> has been placed correctly,
      * <code>False</code> otherwise.
      */
-    boolean put(Entity obj);
+    boolean put(Interactable obj);
 
     /**
      * Returns an <code>Optional</code> containing the <code>Entity</code>
@@ -50,7 +51,7 @@ public interface Tile {
      * @return an <code>Optional</code> with a present value if the tile has
      * something on it, otherwise an empty <code>Optional</code>
      */
-    Optional<Entity> get();
+    Optional<Interactable> get();
 
     /**
      * Removes the <code>Entity</code> that was placed on the tile.
@@ -58,6 +59,6 @@ public interface Tile {
      * @return an <code>Optional</code> with a present value if the tile has
      * something on it, otherwise an empty <code>Optional</code>
      */
-    Optional<Entity> empty();
+    Optional<Interactable> empty();
 
 }

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/Tile.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/Tile.java
@@ -1,6 +1,7 @@
 package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
+import it.unibo.ruscodc.model.effect.SingleTargetEffect;
 import it.unibo.ruscodc.utils.Pair;
 
 import java.util.Optional;
@@ -21,6 +22,18 @@ public interface Tile {
      * @return <code>True</code> if the tile is accessible to the player.
      */
     boolean isAccessible();
+
+    /**
+     * Returns whether the <code>Tile</code> is a trap or not.
+     * @return <code>True</code> if the <code>Tile</code> is a trap, <code>False</code> otherwise
+     */
+    boolean isTrap();
+
+    /**
+     * Returns the effect produced by stepping on the <code>Tile</code>.
+     * @return a <code>SingleTargetEffect</code> representing the effect
+     */
+    SingleTargetEffect getEffect();
 
     /**
      * Places an <code>Entity</code> on the tile.

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/TileFactory.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/TileFactory.java
@@ -9,12 +9,45 @@ import it.unibo.ruscodc.utils.Pair;
 public interface TileFactory {
 
     /**
+     * Creates a new trap tile at the specified position.
+     * The returned trap can be triggered only once.
+     * @param x the x-axis coordinate at which the <code>Tile</code> will be placed
+     * @param y the y-axis coordinate at which the <code>Tile</code> will be placed
+     * @return the new <code>Tile</code>
+     */
+    Tile createSingleUseFloorTrap(int x, int y);
+
+    /**
+     * Creates a new trap tile at the specified position.
+     * @param x the x-axis coordinate at which the <code>Tile</code> will be placed
+     * @param y the y-axis coordinate at which the <code>Tile</code> will be placed
+     * @return the new <code>Tile</code>
+     */
+    Tile createFloorTrap(int x, int y);
+
+    /**
+     * Creates a new random trap tile at the specified position.
+     * @param x the x-axis coordinate at which the <code>Tile</code> will be placed
+     * @param y the y-axis coordinate at which the <code>Tile</code> will be placed
+     * @return the new <code>Tile</code>
+     */
+    Tile createRandomFloorTrap(int x, int y);
+
+    /**
      * Creates a new <code>Tile</code> representing the floor at the specified position.
      * @param x the x-axis coordinate at which the <code>Tile</code> will be placed
      * @param y the y-axis coordinate at which the <code>Tile</code> will be placed
      * @return the new <code>Tile</code>
      */
     Tile createBaseFloorTile(int x, int y);
+
+    /**
+     * Creates a new <code>Tile</code> representing the floor at the specified position.
+     * @param x the x-axis coordinate at which the <code>Tile</code> will be placed
+     * @param y the y-axis coordinate at which the <code>Tile</code> will be placed
+     * @return the new <code>Tile</code>
+     */
+    Tile createRandomFloorTile(int x, int y);
 
     /**
      * Creates a new <code>Tile</code> representing a wall at the specified position.

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/TileFactoryImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/TileFactoryImpl.java
@@ -2,16 +2,51 @@ package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.utils.Pair;
 
+import java.util.Random;
+
 /**
  * The <code>TileFactoryImpl</code> class implements the <code>TileFactory</code>
  * interface and can be used to create different types of <code>Tile</code>.
  */
 public class TileFactoryImpl implements TileFactory {
+    private static final int MAX_TRAP_DMG = 10;
+    private static final int TRAP_PROBABILITY = 5;
+
+    /** {@inheritDoc} */
+    @Override
+    public Tile createSingleUseFloorTrap(final int x, final int y) {
+        FloorTrapTileImpl base = new FloorTrapTileImpl(new Pair<>(x, y));
+        base.setPostTriggered(FloorTrapTileImpl::interact);
+        base.setDamage(new Random().nextInt(1, MAX_TRAP_DMG + 1));
+        return base;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Tile createFloorTrap(final int x, final int y) {
+        FloorTrapTileImpl base = new FloorTrapTileImpl(new Pair<>(x, y));
+        base.setDamage(new Random().nextInt(1, MAX_TRAP_DMG + 1));
+        return base;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Tile createRandomFloorTrap(final int x, final int y) {
+        return (new Random().nextInt() % 2) == 0 ?
+                this.createSingleUseFloorTrap(x, y) : this.createFloorTrap(x, y);
+    }
 
     /** {@inheritDoc} */
     @Override
     public Tile createBaseFloorTile(final int x, final int y) {
         return new FloorTileImpl(new Pair<>(x, y), true);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Tile createRandomFloorTile(final int x, final int y) {
+        return new Random().nextInt(100) < TRAP_PROBABILITY ?
+                this.createRandomFloorTrap(x, y) : this.createBaseFloorTile(x, y);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/it/unibo/ruscodc/model/gamemap/WallTileImpl.java
+++ b/src/main/java/it/unibo/ruscodc/model/gamemap/WallTileImpl.java
@@ -1,6 +1,7 @@
 package it.unibo.ruscodc.model.gamemap;
 
 import it.unibo.ruscodc.model.Entity;
+import it.unibo.ruscodc.model.interactable.Interactable;
 import it.unibo.ruscodc.utils.Pair;
 
 
@@ -24,7 +25,7 @@ public class WallTileImpl extends AbstractTile {
 
     /** {@inheritDoc} */
     @Override
-    public boolean put(final Entity obj) {
+    public boolean put(final Interactable obj) {
         // You cannot put an object in the wall!
         return false;
     }


### PR DESCRIPTION
Tiles' updates
---
- Updates the Tiles' content type using the new interface Interactable.
- Adds a new type of floor tile, introducing the concept of trap. Traps will now be placed among the floor tiles and will inflict damage on the actors trying to step on them. 


Room change handling's updates
---
- Updates the signature of the changeRoom method used by the model to agevolate the use of the existing architecture. The method will now take as input the position of the passageway to use. The side of the room on which it is placed will be authomatically deduced in the model.